### PR TITLE
Make consistent use of XHPROF_LIB_ROOT

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -1,4 +1,8 @@
 <?php
+if (!defined('XHPROF_LIB_ROOT')) {
+    define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
+}
+
 if (PHP_SAPI == 'cli') {
   $_SERVER['REMOTE_ADDR'] = null;
   $_SERVER['HTTP_HOST'] = null;
@@ -6,7 +10,8 @@ if (PHP_SAPI == 'cli') {
   $_GET = $argv;
 }
 
-include(dirname(__FILE__) . '/../xhprof_lib/config.php');
+include(XHPROF_LIB_ROOT . '/config.php');
+
 
 //I'm Magic :)
 class visibilitator
@@ -114,8 +119,8 @@ unset($domain);
 
 //Display warning if extension not available
 if (extension_loaded('tideways') && $_xhprof['doprofile'] === true) {
-    include_once dirname(__FILE__) . '/../xhprof_lib/utils/xhprof_lib.php';
-    include_once dirname(__FILE__) . '/../xhprof_lib/utils/xhprof_runs.php';
+    include_once XHPROF_LIB_ROOT . '/utils/xhprof_lib.php';
+    include_once XHPROF_LIB_ROOT . '/utils/xhprof_runs.php';
     if (isset($ignoredFunctions) && is_array($ignoredFunctions) && !empty($ignoredFunctions)) {
         tideways_enable(TIDEWAYS_FLAGS_CPU | TIDEWAYS_FLAGS_MEMORY | TIDEWAYS_FLAGS_NO_SPANS, array('ignored_functions' => $ignoredFunctions));
     } else {

--- a/xhprof_html/callgraph.php
+++ b/xhprof_html/callgraph.php
@@ -14,6 +14,10 @@
 //  limitations under the License.
 //
 
+if (!defined('XHPROF_LIB_ROOT')) {
+    define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
+}
+
 /**
  *
  * A callgraph generator for XHProf.
@@ -28,17 +32,11 @@
  *
  * @author Changhao Jiang (cjiang@facebook.com)
  */
-require_once ("../xhprof_lib/config.php");
+require_once (XHPROF_LIB_ROOT . "/config.php");
 
 if (false !== $controlIPs && !in_array($_SERVER['REMOTE_ADDR'], $controlIPs))
 {
   die("You do not have permission to view this page.");
-}
-
-// by default assume that xhprof_html & xhprof_lib directories
-// are at the same level.
-if (!defined('XHPROF_LIB_ROOT')) {
-  define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
 }
 
 include_once XHPROF_LIB_ROOT . '/display/xhprof.php';

--- a/xhprof_html/index.php
+++ b/xhprof_html/index.php
@@ -80,7 +80,7 @@ if (!is_null($serverFilter))
 $_xh_header = "";
 if(isset($_GET['run1']) || isset($_GET['run']))
 {
-    include ("../xhprof_lib/templates/header.phtml");
+    include (XHPROF_LIB_ROOT . "/templates/header.phtml");
 	displayXHProfReport($xhprof_runs_impl, $params, $source, $run, $wts,
 	                    $symbol, $sort, $run1, $run2);	
 }elseif (isset($_GET['geturl']))
@@ -94,9 +94,9 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     list($header, $body) = showChart($rs, true);
     $_xh_header .= $header;
     
-    include ("../xhprof_lib/templates/header.phtml");
+    include (XHPROF_LIB_ROOT . "/templates/header.phtml");
     $rs = $xhprof_runs_impl->getRuns($criteria);
-    include ("../xhprof_lib/templates/emptyBody.phtml");
+    include (XHPROF_LIB_ROOT . "/templates/emptyBody.phtml");
     
     $url = htmlentities($_GET['geturl'], ENT_QUOTES, "UTF-8");
     displayRuns($rs, "Runs with URL: $url");
@@ -111,15 +111,15 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     $rs = $xhprof_runs_impl->getUrlStats($criteria);
     list($header, $body) = showChart($rs, true);
     $_xh_header .= $header;
-    include ("../xhprof_lib/templates/header.phtml");
+    include (XHPROF_LIB_ROOT . "/templates/header.phtml");
     
     $url = htmlentities($_GET['getcurl'], ENT_QUOTES, "UTF-8");
     $rs = $xhprof_runs_impl->getRuns($criteria);
-    include("../xhprof_lib/templates/emptyBody.phtml");
+    include(XHPROF_LIB_ROOT . "/templates/emptyBody.phtml");
     displayRuns($rs, "Runs with Simplified URL: $url");
 }elseif (isset($_GET['getruns']))
 {
-    include ("../xhprof_lib/templates/header.phtml");
+    include (XHPROF_LIB_ROOT . "/templates/header.phtml");
     $days = (int) $_GET['days'];
     
     switch ($_GET['getruns'])
@@ -142,7 +142,7 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     displayRuns($rs, "Worst runs by $load");
 }elseif(isset($_GET['hit']))
 {
-    include ("../xhprof_lib/templates/header.phtml");
+    include (XHPROF_LIB_ROOT . "/templates/header.phtml");
     $last = (isset($_GET['hit'])) ?  $_GET['hit'] : 25;
     $last = (int) $last;
     $days = (isset($_GET['days'])) ?  $_GET['days'] : 1;
@@ -203,7 +203,7 @@ if(isset($_GET['run1']) || isset($_GET['run']))
 CODESE;
 }else 
 {
-    include ("../xhprof_lib/templates/header.phtml");
+    include (XHPROF_LIB_ROOT . "/templates/header.phtml");
     $last = (isset($_GET['last'])) ?  $_GET['last'] : 25;
     $last = (int) $last;
     $criteria['order by'] = "timestamp";
@@ -212,4 +212,4 @@ CODESE;
     displayRuns($rs, "Last $last Runs");
 }
 
-include ("../xhprof_lib/templates/footer.phtml");
+include (XHPROF_LIB_ROOT . "/templates/footer.phtml");

--- a/xhprof_lib/display/xhprof.php
+++ b/xhprof_lib/display/xhprof.php
@@ -821,8 +821,8 @@ function print_flat_data($url_params, $title, $flat_data, $sort, $run1, $run2, $
     }
   }
 
-  include( "../xhprof_lib/templates/profChart.phtml");
-  include( "../xhprof_lib/templates/profTable.phtml");
+  include(XHPROF_LIB_ROOT . "/templates/profChart.phtml");
+  include(XHPROF_LIB_ROOT . "/templates/profTable.phtml");
 
 }
 
@@ -858,11 +858,11 @@ function full_report($url_params, $symbol_tab, $sort, $run1, $run2, $links) {
 
   if ($diff_mode) {
       global $xhprof_runs_impl;
-      include "../xhprof_lib/templates/diff_run_header_block.phtml";
+      include XHPROF_LIB_ROOT . "/templates/diff_run_header_block.phtml";
 
   } else {
       global $xhprof_runs_impl;
-    include "../xhprof_lib/templates/single_run_header_block.phtml";
+      include XHPROF_LIB_ROOT . "/templates/single_run_header_block.phtml";
   }
   
   

--- a/xhprof_lib/utils/common.php
+++ b/xhprof_lib/utils/common.php
@@ -95,7 +95,7 @@ function showChart($rs, $flip = false)
   
    
     ob_start();
-      require ("../xhprof_lib/templates/chart.phtml");   
+      require (XHPROF_LIB_ROOT . "/templates/chart.phtml");
       $stuff = ob_get_contents();
     ob_end_clean();
    return array($stuff, "<div id=\"container\" style=\"width: 1000px; height: 500px; margin: 0 auto\"></div>");


### PR DESCRIPTION
Sometimes XHPROF_LIB_ROOT was set and used. Sometimes it was just ignored. Using a consistent way of including files, makes custom setups more easy.