### PR TITLE
fix profiling weight if 0, rand(1,0) returns 1

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -86,7 +86,7 @@ unset($exceptionPostURLs);
 if ($_xhprof['doprofile'] === false)
 {
     //Profile weighting, one in one hundred requests will be profiled without being specifically requested
-    if (rand(1, $weight) == 1)
+    if ($weight > 0 && rand(1, $weight) == 1)
     {
         $_xhprof['doprofile'] = true;
         $_xhprof['type'] = 0;


### PR DESCRIPTION
Given this config:
```php
$_xhprof['doprofile'] = false;
$weight = 0;
```
The following code within header.php would cause the profiler to run any time (as it would be the case when `$weight=1`):
```php
//Determine wether or not to profile this URL randomly
if ($_xhprof['doprofile'] === false)
{
    //Profile weighting, one in one hundred requests will be profiled without being specifically requested
    if (rand(1, $weight) == 1)
    {
        $_xhprof['doprofile'] = true;
        $_xhprof['type'] = 0;
    } 
}
unset($weight);
```

This is due to the fact that `rand(1,0)` returns 1!
All of this return 1:
```php
var_dump(rand(1,1));
var_dump(rand(1,0));
var_dump(rand(1,null));
var_dump(rand(1,false));
```